### PR TITLE
Fix Markdown Linting Issues for Improved Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ pip3 install aiocomfoconnect
 ## CLI Usage
 
 ```shell
-$ python -m aiocomfoconnect --help
+python -m aiocomfoconnect --help
 
-$ python -m aiocomfoconnect discover
+python -m aiocomfoconnect discover
 
-$ python -m aiocomfoconnect register --host 192.168.1.213
+python -m aiocomfoconnect register --host 192.168.1.213
 
-$ python -m aiocomfoconnect set-speed away --host 192.168.1.213
-$ python -m aiocomfoconnect set-speed low --host 192.168.1.213
-$ python -m aiocomfoconnect set-mode auto --host 192.168.1.213
-$ python -m aiocomfoconnect set-speed medium --host 192.168.1.213
-$ python -m aiocomfoconnect set-speed high --host 192.168.1.213
-$ python -m aiocomfoconnect set-boost on --host 192.168.1.213 --timeout 1200
+python -m aiocomfoconnect set-speed away --host 192.168.1.213
+python -m aiocomfoconnect set-speed low --host 192.168.1.213
+python -m aiocomfoconnect set-mode auto --host 192.168.1.213
+python -m aiocomfoconnect set-speed medium --host 192.168.1.213
+python -m aiocomfoconnect set-speed high --host 192.168.1.213
+python -m aiocomfoconnect set-boost on --host 192.168.1.213 --timeout 1200
 
-$ python -m aiocomfoconnect set-comfocool auto --host 192.168.1.213
-$ python -m aiocomfoconnect set-comfocool off --host 192.168.1.213
+python -m aiocomfoconnect set-comfocool auto --host 192.168.1.213
+python -m aiocomfoconnect set-comfocool off --host 192.168.1.213
 
-$ python -m aiocomfoconnect show-sensors --host 192.168.1.213
-$ python -m aiocomfoconnect show-sensor 276 --host 192.168.1.213
-$ python -m aiocomfoconnect show-sensor 276 --host 192.168.1.213 -f
+python -m aiocomfoconnect show-sensors --host 192.168.1.213
+python -m aiocomfoconnect show-sensor 276 --host 192.168.1.213
+python -m aiocomfoconnect show-sensor 276 --host 192.168.1.213 -f
 
-$ python -m aiocomfoconnect get-property --host 192.168.1.213 1 1 8 9  # Unit 0x01, SubUnit 0x01, Property 0x08, Type STRING. See PROTOCOL-RMI.md
+python -m aiocomfoconnect get-property --host 192.168.1.213 1 1 8 9  # Unit 0x01, SubUnit 0x01, Property 0x08, Type STRING. See PROTOCOL-RMI.md
 ```
 
 ## Available methods
@@ -154,8 +154,8 @@ You can use the `scripts/decode_pcap.py` file to decode network traffic between 
 Make sure that the first TCP session in the capture is the connection between the bridge and the app. It's therefore recommended to start the capture before you open the app.
 
 ```shell
-$ sudo tcpdump -i any -s 0 -w /tmp/capture.pcap tcp and port 56747
-$ python3 script/decode_pcap.py /tmp/capture.pcap
+sudo tcpdump -i any -s 0 -w /tmp/capture.pcap tcp and port 56747
+python3 script/decode_pcap.py /tmp/capture.pcap
 ```
 
 ### Generate zehnder_pb2.py file

--- a/docs/PROTOCOL-PDO.md
+++ b/docs/PROTOCOL-PDO.md
@@ -64,7 +64,7 @@ Numbers are stored in little endian format.
 | 117  | CN_UINT8  | Fans: Exhaust fan duty                           | value in % (28%)                                                                                                 |
 | 118  | CN_UINT8  | Fans: Supply fan duty                            | value in % (29%)                                                                                                 |
 | 119  | CN_UINT16 | Fans: Exhaust fan flow                           | value in m³/h (110 m³/h)                                                                                         |
-| 120  | CN_UINT16 | Fans: Supply fan flow                            | value in m³/h (105 m³/h                                                                                          |
+| 120  | CN_UINT16 | Fans: Supply fan flow                            | value in m³/h (105 m³/h)                                                                                         |
 | 121  | CN_UINT16 | Fans: Exhaust fan speed                          | value in rpm (1069 rpm)                                                                                          |
 | 122  | CN_UINT16 | Fans: Supply fan speed                           | value in rpm (1113 rpm)                                                                                          |
 | 128  | CN_UINT16 | Power Consumption: Current Ventilation           | value in Watt (15 W)                                                                                             |

--- a/docs/PROTOCOL-PDO.md
+++ b/docs/PROTOCOL-PDO.md
@@ -17,7 +17,7 @@ Numbers are stored in little endian format.
 | 10   | CN_TIME     |                           |
 | 11   | CN_VERSION  |                           |
 
-# Overview of known sensors
+## Overview of known sensors
 
 | pdid | type      | description                                      | examples                                                                                                         |
 |------|-----------|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------|

--- a/docs/PROTOCOL-RMI.md
+++ b/docs/PROTOCOL-RMI.md
@@ -65,10 +65,10 @@ There are three commands which always exist on a given Unit:
   Syntax: `01 Unit SubUnit Type Property`
 
   The `Type` can be one of the following:
-    - 0x00: None
-    - 0x10: Actual value
-    - 0x20: Range
-    - 0x40: Step size
+  - 0x00: None
+  - 0x10: Actual value
+  - 0x20: Range
+  - 0x40: Step size
 
   Each writable property may have a range & step size. You can get those values by using the `0x20` and `0x40` `Type` values. You can request multiple types
   at the same time by OR'ing the value.
@@ -87,11 +87,11 @@ There are three commands which always exist on a given Unit:
 
   Example: Request: `02 01 01 01 15 03 04 06 05 14`, Response: `\02 BEA000000000000\00 \00\10\10\c0 \02 ComfoAirQ\00`
   This reads the following property values:
-    - 0x03: ???
-    - 0x04: Serial Number
-    - 0x06: Firmware version
-    - 0x05: ???
-    - 0x14: Ventilation Unit Name
+  - 0x03: ???
+  - 0x04: Serial Number
+  - 0x06: Firmware version
+  - 0x05: ???
+  - 0x14: Ventilation Unit Name
 
 - `0x03`: Set a single property
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -327,7 +327,7 @@ Two basic assumptions:
 
 If your ventilation is set to something else you need to try it out
 
-## Quick Overview of the network:
+## Quick Overview of the network
 
 Speed is 100kb/s, no CAN-FD but extended ID's are used (one exception: firmware uploading)
 Each device has an unique node-id smaller than 0x3F or 64. If a device detects that another device is writing using "his" id, the device will change its id

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -60,7 +60,7 @@ Buffers.
 
 Raw response data:
 
-```
+```text
 12230a0d3139322e3136382e312e32313312100000000000251010800170b3d54264b41801
 ```
 
@@ -341,7 +341,7 @@ Firmware-Updates are sent using 11-bit IDs or 1F800000
 
 RMI-Commands are sent and received using extended-IDs:
 
-```
+```text
     1F000000
     + SrcAddr        << 0 6 bits  source Node-Id
     + DstAddr        << 6 6 bits  destination Node-Id
@@ -354,7 +354,7 @@ RMI-Commands are sent and received using extended-IDs:
 
 Some Examples:
 
-```
+```text
 1F015057: 11111 0000 0001 0101 00 0001 010111 multi-msg request with SeqNr = 0
 1F011074: 11111 0000 0001 0001 00 0001 110100 single-msg request with SeqNr = 0
 1F071074: 11111 0000 0111 0001 00 0001 110100 single-msg request with SeqNr = 3
@@ -375,7 +375,8 @@ There are two ways of messaging them:
    Example:
    Request: `01 1D 01 10 0A` (Get (`0x01`) from Unit `1D 01` (`TEMPHUMCONTROL 01`) exact value (`10`) variable `0A` (`Target Temperature Warm`))
    Response: `E6 00` little-endian encoded, `0x00E6 = 230 = 23.0°C`
-   ```
+
+   ```text
        can1  1F011074   [5]  01 1D 01 10 0A
        can1  1F001D01   [2]  E6 00
    ```
@@ -385,7 +386,8 @@ There are two ways of messaging them:
 
    Example:
    CMI-Request: `80 03 01`, answer `00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00`
-   ```
+
+   ```text
        can1  1F011074   [3]  80 03 01  # I send
        can1  1F005D01   [8]  00 00 00 00 00 00 00 00  # Answer
        can1  1F005D01   [8]  01 00 00 00 00 00 00 00

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -31,7 +31,7 @@ msg_____________________________________________________________________________
 Command:
 
 ```sh
-$ echo "08022002" | xxd -r -p | protoc --decode=GatewayOperation zehnder.proto
+echo "08022002" | xxd -r -p | protoc --decode=GatewayOperation zehnder.proto
 ```
 
 ```javascript
@@ -42,7 +42,7 @@ reference: 2
 Message:
 
 ```sh
-$ echo "0a10a886190220044d68a07d85a2e3866fce10001a126950686f6e652076616e2044657374696e79" | xxd -r -p | protoc --decode=RegisterAppRequest zehnder.proto
+echo "0a10a886190220044d68a07d85a2e3866fce10001a126950686f6e652076616e2044657374696e79" | xxd -r -p | protoc --decode=RegisterAppRequest zehnder.proto
 ```
 
 ```javascript


### PR DESCRIPTION
# Markdown Lint Corrections

This pull request addresses various Markdown linting issues to improve the consistency and correctness of the documentation. The following changes have been made:

- **Corrected Dollar Sign Usage**: Fixed instances where dollar signs were used before commands without showing output, addressing `MD014/commands-show-output`.

- **Fixed Heading and List Formatting**:
  - Ensured there is only one top-level heading in the document, resolving `MD025/single-title/single-h1`.
  - Corrected unordered list indentation to match expected values, fixing `MD007/ul-indent`.

- **Removed Trailing Punctuation**: Eliminated trailing punctuation in headings, specifically colons, to comply with `MD026/no-trailing-punctuation`.

- **Improved Code Block Formatting**:
  - Added language specifications to fenced code blocks to satisfy `MD040/fenced-code-language`.
  - Ensured fenced code blocks are surrounded by blank lines, addressing `MD031/blanks-around-fences`.

- **Syntax Correction**: Added a missing closing parenthesis to correct syntax errors.

These updates enhance the readability and maintainability of the documentation.
