### PR TITLE
Add comprehensive .gitignore for Python development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,32 @@
-*.py
-.idea/
-__pycache__
-dist/
+# Temporary pcap files
 script/*.pcap
+
+# Bytecode files
+*.py[oc]
+__pycache__/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Python-generated files
+build/
+dist/
+
+# uv cache
+.uv-cache/
+
+# Visual Studio Code Settings and files
+.vscode
+.idea/
+
+# Virtual environments
+.venv
+
+# Local environments
 .env
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Add comprehensive .gitignore for Python development

- Exclude Python bytecode files (*.pyc, *.pyo, __pycache__)
- Ignore virtual environments (.venv/, venv/, env/)
- Skip build artifacts (build/, dist/)
- Exclude uv cache (.uv-cache/)
- Ignore editor settings (.vscode/, .idea/)
- Filter OS-specific files (.DS_Store, Thumbs.db)
- Exclude environment files (.env)