### PR TITLE
feat(cli): add enum-based ventilation mode support

### DIFF
--- a/aiocomfoconnect/__main__.py
+++ b/aiocomfoconnect/__main__.py
@@ -317,6 +317,51 @@ async def run_set_bypass(args: argparse.Namespace) -> None:
     await with_connected_bridge(args.host, args.uuid, do_set_bypass, args.mode)
 
 
+async def run_get_sensor_ventmode_temperature_passive(args: argparse.Namespace) -> None:
+    """Get the current sensor-based ventilation mode (temperature passive)."""
+    async def do_get(comfoconnect):
+        mode = await comfoconnect.get_sensor_ventmode_temperature_passive()
+        print(str(mode))
+    await with_connected_bridge(args.host, args.uuid, do_get)
+
+
+async def run_set_sensor_ventmode_temperature_passive(args: argparse.Namespace) -> None:
+    """Set the sensor-based ventilation mode (temperature passive)."""
+    async def do_set(comfoconnect, mode):
+        await comfoconnect.set_sensor_ventmode_temperature_passive(mode)
+    await with_connected_bridge(args.host, args.uuid, do_set, args.mode)
+
+
+async def run_get_sensor_ventmode_humidity_comfort(args: argparse.Namespace) -> None:
+    """Get the current sensor-based ventilation mode (humidity comfort)."""
+    async def do_get(comfoconnect):
+        mode = await comfoconnect.get_sensor_ventmode_humidity_comfort()
+        print(str(mode))
+    await with_connected_bridge(args.host, args.uuid, do_get)
+
+
+async def run_set_sensor_ventmode_humidity_comfort(args: argparse.Namespace) -> None:
+    """Set the sensor-based ventilation mode (humidity comfort)."""
+    async def do_set(comfoconnect, mode):
+        await comfoconnect.set_sensor_ventmode_humidity_comfort(mode)
+    await with_connected_bridge(args.host, args.uuid, do_set, args.mode)
+
+
+async def run_get_sensor_ventmode_humidity_protection(args: argparse.Namespace) -> None:
+    """Get the current sensor-based ventilation mode (humidity protection)."""
+    async def do_get(comfoconnect):
+        mode = await comfoconnect.get_sensor_ventmode_humidity_protection()
+        print(str(mode))
+    await with_connected_bridge(args.host, args.uuid, do_get)
+
+
+async def run_set_sensor_ventmode_humidity_protection(args: argparse.Namespace) -> None:
+    """Set the sensor-based ventilation mode (humidity protection)."""
+    async def do_set(comfoconnect, mode):
+        await comfoconnect.set_sensor_ventmode_humidity_protection(mode)
+    await with_connected_bridge(args.host, args.uuid, do_set, args.mode)
+
+
 async def main(args: argparse.Namespace) -> None:
     """Main entry point for the CLI."""
     await args.func(args)
@@ -420,6 +465,38 @@ if __name__ == "__main__":
     p_set_bypass.add_argument("--host", help="Host address of the bridge")
     p_set_bypass.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
     p_set_bypass.set_defaults(func=run_set_bypass)
+    p_get_sensor_temp_passive = subparsers.add_parser("get-sensor-ventmode-temperature-passive", help="Get the current sensor-based ventilation mode (temperature passive)")
+    p_get_sensor_temp_passive.add_argument("--host", help="Host address of the bridge")
+    p_get_sensor_temp_passive.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
+    p_get_sensor_temp_passive.set_defaults(func=run_get_sensor_ventmode_temperature_passive)
+
+    p_set_sensor_temp_passive = subparsers.add_parser("set-sensor-ventmode-temperature-passive", help="Set the sensor-based ventilation mode (temperature passive)")
+    p_set_sensor_temp_passive.add_argument("mode", help="Mode", choices=["auto", "on", "off"])
+    p_set_sensor_temp_passive.add_argument("--host", help="Host address of the bridge")
+    p_set_sensor_temp_passive.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
+    p_set_sensor_temp_passive.set_defaults(func=run_set_sensor_ventmode_temperature_passive)
+
+    p_get_sensor_hum_comfort = subparsers.add_parser("get-sensor-ventmode-humidity-comfort", help="Get the current sensor-based ventilation mode (humidity comfort)")
+    p_get_sensor_hum_comfort.add_argument("--host", help="Host address of the bridge")
+    p_get_sensor_hum_comfort.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
+    p_get_sensor_hum_comfort.set_defaults(func=run_get_sensor_ventmode_humidity_comfort)
+
+    p_set_sensor_hum_comfort = subparsers.add_parser("set-sensor-ventmode-humidity-comfort", help="Set the sensor-based ventilation mode (humidity comfort)")
+    p_set_sensor_hum_comfort.add_argument("mode", help="Mode", choices=["auto", "on", "off"])
+    p_set_sensor_hum_comfort.add_argument("--host", help="Host address of the bridge")
+    p_set_sensor_hum_comfort.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
+    p_set_sensor_hum_comfort.set_defaults(func=run_set_sensor_ventmode_humidity_comfort)
+
+    p_get_sensor_hum_protection = subparsers.add_parser("get-sensor-ventmode-humidity-protection", help="Get the current sensor-based ventilation mode (humidity protection)")
+    p_get_sensor_hum_protection.add_argument("--host", help="Host address of the bridge")
+    p_get_sensor_hum_protection.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
+    p_get_sensor_hum_protection.set_defaults(func=run_get_sensor_ventmode_humidity_protection)
+
+    p_set_sensor_hum_protection = subparsers.add_parser("set-sensor-ventmode-humidity-protection", help="Set the sensor-based ventilation mode (humidity protection)")
+    p_set_sensor_hum_protection.add_argument("mode", help="Mode", choices=["auto", "on", "off"])
+    p_set_sensor_hum_protection.add_argument("--host", help="Host address of the bridge")
+    p_set_sensor_hum_protection.add_argument("--uuid", help="UUID of this app", default=DEFAULT_UUID)
+    p_set_sensor_hum_protection.set_defaults(func=run_set_sensor_ventmode_humidity_protection)
   
     arguments = parser.parse_args()
     if arguments.debug:

--- a/aiocomfoconnect/comfoconnect.py
+++ b/aiocomfoconnect/comfoconnect.py
@@ -627,90 +627,98 @@ class ComfoConnect(Bridge):
                 raise ValueError(f"Invalid temperature profile: {profile}")
         await self.set_temperature_profile_enum(enum_profile, timeout)
 
-    async def get_sensor_ventmode_temperature_passive(self) -> str:
-        """Get sensor based ventilation mode - temperature passive (auto / on / off)."""
+    async def get_sensor_ventmode_temperature_passive_enum(self) -> VentilationSetting:
+        """Get sensor based ventilation mode - temperature passive as enum (AUTO / ON / OFF)."""
         result = await self.cmd_rmi_request(bytes([self._CMD_GET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x10, 0x04]))
         mode = int.from_bytes(result.message, "little")
-        match mode:
-            case 1:
-                return VentilationSetting.AUTO
-            case 2:
-                return VentilationSetting.ON
-            case 0:
-                return VentilationSetting.OFF
-            case _:
-                raise ValueError(f"Invalid mode: {mode}")
+        try:
+            return VentilationSetting(mode)
+        except ValueError:
+            raise ValueError(f"Invalid mode: {mode}")
 
-    async def set_sensor_ventmode_temperature_passive(self, mode: Literal["auto", "on", "off"]) -> None:
-        """Configure sensor based ventilation mode - temperature passive (auto / on / off)."""
-        match mode:
-            case VentilationSetting.AUTO:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x04, 0x01]))
-            case VentilationSetting.ON:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x04, 0x02]))
-            case VentilationSetting.OFF:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x04, 0x00]))
-            case _:
-                raise ValueError(f"Invalid mode: {mode}")
+    async def get_sensor_ventmode_temperature_passive(self) -> str:
+        """Backwards-compatible: Get sensor based ventilation mode - temperature passive as string ('auto', 'on', 'off')."""
+        mode_enum = await self.get_sensor_ventmode_temperature_passive_enum()
+        return str(mode_enum)
 
-    async def get_sensor_ventmode_humidity_comfort(self) -> str:
-        """Get sensor based ventilation mode - humidity comfort (auto / on / off)."""
+    async def set_sensor_ventmode_temperature_passive_enum(self, mode: VentilationSetting) -> None:
+        """Set sensor based ventilation mode - temperature passive using enum (AUTO / ON / OFF)."""
+        if not isinstance(mode, VentilationSetting):
+            raise ValueError(f"Invalid mode: {mode}")
+        await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x04, mode.value]))
+
+    async def set_sensor_ventmode_temperature_passive(self, mode: str) -> None:
+        """Backwards-compatible: Set sensor based ventilation mode - temperature passive using string ('auto', 'on', 'off')."""
+        try:
+            mode_enum = VentilationSetting[mode.strip().upper()]
+        except KeyError:
+            try:
+                mode_enum = VentilationSetting(int(mode))
+            except Exception:
+                raise ValueError(f"Invalid mode: {mode}")
+        await self.set_sensor_ventmode_temperature_passive_enum(mode_enum)
+
+    async def get_sensor_ventmode_humidity_comfort_enum(self) -> VentilationSetting:
+        """Get sensor based ventilation mode - humidity comfort as enum (AUTO / ON / OFF)."""
         result = await self.cmd_rmi_request(bytes([self._CMD_GET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x10, 0x06]))
         mode = int.from_bytes(result.message, "little")
-        match mode:
-            case 1:
-                return VentilationSetting.AUTO
-            case 2:
-                return VentilationSetting.ON
-            case 0:
-                return VentilationSetting.OFF
-            case _:
-                raise ValueError(f"Invalid mode: {mode}")
+        try:
+            return VentilationSetting(mode)
+        except ValueError:
+            raise ValueError(f"Invalid mode: {mode}")
 
-    async def set_sensor_ventmode_humidity_comfort(self, mode: Literal["auto", "on", "off"]) -> None:
-        """Configure sensor based ventilation mode - humidity comfort (auto / on / off)."""
-        match mode:
-            case VentilationSetting.AUTO:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x06, 0x01]))
-            case VentilationSetting.ON:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x06, 0x02]))
-            case VentilationSetting.OFF:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x06, 0x00]))
-            case _:
-                raise ValueError(f"Invalid mode: {mode}")
+    async def get_sensor_ventmode_humidity_comfort(self) -> str:
+        """Backwards-compatible: Get sensor based ventilation mode - humidity comfort as string ('auto', 'on', 'off')."""
+        mode_enum = await self.get_sensor_ventmode_humidity_comfort_enum()
+        return str(mode_enum)
 
-    async def get_sensor_ventmode_humidity_protection(self) -> str:
-        """Get sensor based ventilation mode - humidity protection (auto / on / off)."""
+    async def set_sensor_ventmode_humidity_comfort_enum(self, mode: VentilationSetting) -> None:
+        """Set sensor based ventilation mode - humidity comfort using enum (AUTO / ON / OFF)."""
+        if not isinstance(mode, VentilationSetting):
+            raise ValueError(f"Invalid mode: {mode}")
+        await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x06, mode.value]))
+
+    async def set_sensor_ventmode_humidity_comfort(self, mode: str) -> None:
+        """Backwards-compatible: Set sensor based ventilation mode - humidity comfort using string ('auto', 'on', 'off')."""
+        try:
+            mode_enum = VentilationSetting[mode.strip().upper()]
+        except KeyError:
+            try:
+                mode_enum = VentilationSetting(int(mode))
+            except Exception:
+                raise ValueError(f"Invalid mode: {mode}")
+        await self.set_sensor_ventmode_humidity_comfort_enum(mode_enum)
+
+    async def get_sensor_ventmode_humidity_protection_enum(self) -> VentilationSetting:
+        """Get sensor based ventilation mode - humidity protection as enum (AUTO / ON / OFF)."""
         result = await self.cmd_rmi_request(bytes([self._CMD_GET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x10, 0x07]))
         mode = int.from_bytes(result.message, "little")
-        match mode:
-            case 1:
-                return VentilationSetting.AUTO
-            case 2:
-                return VentilationSetting.ON
-            case 0:
-                return VentilationSetting.OFF
-            case _:
+        try:
+            return VentilationSetting(mode)
+        except ValueError:
+            raise ValueError(f"Invalid mode: {mode}")
+
+    async def get_sensor_ventmode_humidity_protection(self) -> str:
+        """Backwards-compatible: Get sensor based ventilation mode - humidity protection as string ('auto', 'on', 'off')."""
+        mode_enum = await self.get_sensor_ventmode_humidity_protection_enum()
+        return str(mode_enum)
+
+    async def set_sensor_ventmode_humidity_protection_enum(self, mode: VentilationSetting) -> None:
+        """Set sensor based ventilation mode - humidity protection using enum (AUTO / ON / OFF)."""
+        if not isinstance(mode, VentilationSetting):
+            raise ValueError(f"Invalid mode: {mode}")
+        await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x07, mode.value]))
+
+    async def set_sensor_ventmode_humidity_protection(self, mode: str) -> None:
+        """Backwards-compatible: Set sensor based ventilation mode - humidity protection using string ('auto', 'on', 'off')."""
+        try:
+            mode_enum = VentilationSetting[mode.strip().upper()]
+        except KeyError:
+            try:
+                mode_enum = VentilationSetting(int(mode))
+            except Exception:
                 raise ValueError(f"Invalid mode: {mode}")
-
-    async def set_sensor_ventmode_humidity_protection(self, mode: Literal["auto", "on", "off"]) -> None:
-        """Configure sensor-based ventilation mode - humidity protection.
-
-        Args:
-            mode (Literal["auto", "on", "off"]): Desired mode.
-
-        Raises:
-            ValueError: If the mode is invalid.
-        """
-        match mode:
-            case VentilationSetting.AUTO:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x07, 0x01]))
-            case VentilationSetting.ON:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x07, 0x02]))
-            case VentilationSetting.OFF:
-                await self.cmd_rmi_request(bytes([self._CMD_SET_PROPERTY, UNIT_TEMPHUMCONTROL, SUBUNIT_01, 0x07, 0x00]))
-            case _:
-                raise ValueError(f"Invalid mode: {mode}")
+        await self.set_sensor_ventmode_humidity_protection_enum(mode_enum)
 
     async def clear_errors(self):
         """Clear the errors."""

--- a/aiocomfoconnect/const.py
+++ b/aiocomfoconnect/const.py
@@ -178,12 +178,13 @@ class VentilationMode:
     AUTO = "auto"
 
 
-class VentilationSetting:
-    """Enum for ventilation settings."""
+class VentilationSetting(IntEnum):
+    OFF = 0x00
+    AUTO = 0x01
+    ON = 0x02
 
-    AUTO = "auto"
-    ON = "on"
-    OFF = "off"
+    def __str__(self) -> str:
+        return self.name.lower()
 
 
 class VentilationBalance:


### PR DESCRIPTION
- Add CLI commands for get/set_sensor_ventmode_humidity_comfort and get/set_sensor_ventmode_humidity_protection using IntEnum
- Add IntEnum for VentilationSetting to ensure robust mapping between protocol values and strings
- Add CLI support for get/set_sensor_ventmode_temperature_passive
- Ensure backwards compatibility with string-based CLI usage
- Improve error handling for invalid values

This change modernizes the CLI interface for ventilation settings, making it type-safe and easier to maintain.