### PR TITLE
fix(discovery): resolve Windows broadcast discovery failure with ProactorEventLoop

### DIFF
--- a/aiocomfoconnect/discovery.py
+++ b/aiocomfoconnect/discovery.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from typing import Any, List, Union
 
+import netifaces
+
 from .bridge import Bridge
 from .protobuf import zehnder_pb2
 
@@ -15,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class BridgeDiscoveryProtocol(asyncio.DatagramProtocol):
     """UDP Protocol for the ComfoConnect LAN C bridge discovery."""
 
-    def __init__(self, target: str = None, timeout: int = 5):
+    def __init__(self, target: str | None = None, timeout: int = 5):
         loop = asyncio.get_running_loop()
 
         self._bridges: List[Bridge] = []
@@ -33,8 +35,17 @@ class BridgeDiscoveryProtocol(asyncio.DatagramProtocol):
             _LOGGER.debug("Sending discovery request to %s:%d", self._target, Bridge.PORT)
             self.transport.sendto(b"\x0a\x00", (self._target, Bridge.PORT))
         else:
-            _LOGGER.debug("Sending discovery request to broadcast:%d", Bridge.PORT)
-            self.transport.sendto(b"\x0a\x00", ("<broadcast>", Bridge.PORT))
+            # Determine broadcast address programmatically
+            try:
+                gws = netifaces.gateways()
+                default_iface = gws['default'][netifaces.AF_INET][1]
+                addrs = netifaces.ifaddresses(default_iface)
+                broadcast_addr = addrs[netifaces.AF_INET][0].get('broadcast', '255.255.255.255')
+            except Exception as e:
+                _LOGGER.warning("Could not determine broadcast address, using 255.255.255.255: %s", e)
+                broadcast_addr = '255.255.255.255'
+            _LOGGER.debug("Sending discovery request to broadcast:%d (%s)", Bridge.PORT, broadcast_addr)
+            self.transport.sendto(b"\x0a\x00", (broadcast_addr, Bridge.PORT))
 
     def datagram_received(self, data: Union[bytes, str], addr: tuple[str | Any, int]):
         """Called when some datagram is received."""
@@ -43,12 +54,15 @@ class BridgeDiscoveryProtocol(asyncio.DatagramProtocol):
             return
 
         _LOGGER.debug("Data received from %s: %s", addr, data)
+        try:
+            # Decode the response
+            parser = zehnder_pb2.DiscoveryOperation()  # pylint: disable=no-member
+            parser.ParseFromString(data)
 
-        # Decode the response
-        parser = zehnder_pb2.DiscoveryOperation()  # pylint: disable=no-member
-        parser.ParseFromString(data)
-
-        self._bridges.append(Bridge(host=parser.searchGatewayResponse.ipaddress, uuid=parser.searchGatewayResponse.uuid.hex()))
+            self._bridges.append(Bridge(host=parser.searchGatewayResponse.ipaddress, uuid=parser.searchGatewayResponse.uuid.hex()))
+        except Exception as exc:
+            _LOGGER.error("Failed to parse discovery response from %s: %s", addr, exc)
+            return
 
         # When we have passed a target, we only want to listen for that one
         if self._target:
@@ -66,8 +80,30 @@ class BridgeDiscoveryProtocol(asyncio.DatagramProtocol):
         return self._future
 
 
-async def discover_bridges(host: str = None, timeout: int = 1, loop=None) -> List[Bridge]:
-    """Discover a bridge by IP."""
+async def discover_bridges(host: str | None = None, timeout: int = 1, loop=None) -> List[Bridge]:
+    """
+    Discover ComfoConnect bridges on the local network or at a specified host.
+
+    This asynchronous function sends a UDP broadcast (or unicast if a host is specified)
+    to discover available ComfoConnect bridges. It returns a list of discovered Bridge
+    instances.
+
+    Args:
+        host (str | None): The IP address of a specific bridge to discover. If None,
+            a broadcast is sent to discover all available bridges. Defaults to None.
+        timeout (int): The time in seconds to wait for responses. Defaults to 1.
+        loop (asyncio.AbstractEventLoop, optional): The event loop to use. If None,
+            the default event loop is used.
+
+    Returns:
+        List[Bridge]: A list of discovered Bridge objects.
+
+    Raises:
+        Any exceptions raised by the underlying asyncio transport or protocol.
+
+    Example:
+        bridges = await discover_bridges(timeout=2)
+    """
 
     if loop is None:
         loop = asyncio.get_event_loop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/michaelarnauts/aiocomfoconnect"
 python = "^3.10"
 aiohttp = "^3.8.0"
 protobuf = "^6.31"
+netifaces = "^0.11.0"
 
 [tool.poetry.group.dev.dependencies]
 grpcio-tools = "^1.73.0"


### PR DESCRIPTION
## Problem

Discovery fails silently on Windows systems due to ProactorEventLoop not properly handling the `"<broadcast>"` address, resulting in UDP packets not reaching the network interface. This particularly affects Windows systems with complex network configurations (multiple adapters, VirtualBox, WSL, etc.).

**Fixes #61**

## Root Cause

The hardcoded `"<broadcast>"` string in `discovery.py:39` works on Linux SelectorEventLoop but fails on Windows ProactorEventLoop, causing silent discovery failures where no bridges are found despite being present on the network.

## Solution

- Replace hardcoded `"<broadcast>"` with programmatic broadcast address detection using `netifaces`
- Add robust fallback to `255.255.255.255` when interface detection fails
- Improve error handling around protobuf parsing
- Add comprehensive documentation and logging

## Testing

### Before (Windows)
```
Discovered bridges:
```

### After (Windows)
```
Discovered bridges:
<Bridge 192.168.xxx.yy, UID=000000000022xxxxxxxxxxxxxxxxxxxx>
```

### Cross-platform compatibility
- ✅ **Windows**: Now works with ProactorEventLoop
- ✅ **Linux**: Continues to work (tested on both platforms)
- ✅ **Fallback**: Graceful degradation when network detection fails

## Changes

- Add `netifaces` dependency for network interface detection
- Enhance broadcast address resolution logic
- Improve error handling and logging
- Modernize type hints to Python 3.10+ standards
- Add comprehensive function documentation

## Breaking Changes

None - maintains full backward compatibility.